### PR TITLE
Fixes against recent HAML 5.x

### DIFF
--- a/.github/workflows/gem_build_test.yml
+++ b/.github/workflows/gem_build_test.yml
@@ -1,10 +1,6 @@
 name: Gem Test
 
 on:
-  push:
-    branches:
-    - master
-    - tmp/*
   pull_request:
     branches:
     - master

--- a/.github/workflows/gem_build_test.yml
+++ b/.github/workflows/gem_build_test.yml
@@ -6,14 +6,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
+    strategy:
+      matrix:
+        ruby: [ '2.x', '3.x' ]
+    name: Test on Ruby ${{ matrix.ruby }}
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Ruby 2.6.3
-      uses: actions/setup-ruby@v1
-      with:
-        version: 2.6.3
-    - name: Build and test with Rake
-      run: |
-        gem build erb2slim.gemspec
-        ruby -Ilib:test tests/test_simple.rb
+      - uses: actions/checkout@master
+      - name: Setup ruby ${{ matrix.ruby }}
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          architecture: 'x64'
+      - name: Build and test with Rake
+        run: |
+          gem build erb2slim.gemspec
+          ruby -Ilib:test tests/test_simple.rb

--- a/.github/workflows/gem_build_test.yml
+++ b/.github/workflows/gem_build_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.x', '3.x' ]
+        ruby: [ '2.x' ]
     name: Test on Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/gem_build_test.yml
+++ b/.github/workflows/gem_build_test.yml
@@ -1,0 +1,19 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 2.6.3
+      uses: actions/setup-ruby@v1
+      with:
+        version: 2.6.3
+    - name: Build and test with Rake
+      run: |
+        gem build erb2slim.gemspec
+        ruby -Ilib:test tests/test_simple.rb

--- a/.github/workflows/gem_build_test.yml
+++ b/.github/workflows/gem_build_test.yml
@@ -1,13 +1,19 @@
-name: Ruby
+name: Gem Test
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+    - tmp/*
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.x', '3.x' ]
     name: Test on Ruby ${{ matrix.ruby }}

--- a/.github/workflows/gem_build_test.yml
+++ b/.github/workflows/gem_build_test.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           architecture: 'x64'
-      - name: Build and test with Rake
+      - name: Build and test
         run: |
-          gem build erb2slim.gemspec
+          bundle install
           ruby -Ilib:test tests/test_simple.rb

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 *.gem
 *.rbc
 .bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ require 'erb2slim'
 slim_template_string = Erb2Slim.convert(erb_template_string)
 ```
 
+Or the executable utility installed with the gem:
+
+```
+erb2slim my_template.erb
+```
 
 ## How it works
 

--- a/bin/erb2slim
+++ b/bin/erb2slim
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'erb2slim'
+
+erb = IO.read(ARGV[0])
+
+STDOUT << Erb2Slim.convert(erb)

--- a/erb2slim.gemspec
+++ b/erb2slim.gemspec
@@ -8,8 +8,9 @@ Gem::Specification.new do |spec|
   spec.homepage     = 'https://github.com/c0untd0wn/erb2slim'
   spec.files        = `git ls-files --  lib/* bin/* README.md`.split("\n")
 
-  spec.add_dependency 'haml'
-  spec.add_dependency 'hpricot'
-  spec.add_dependency 'erubis'
-  spec.add_dependency 'haml2slim'
+  spec.add_dependency 'haml', '~>5.1.2'
+  spec.add_dependency 'html2haml', '~>2.2.0'
+  spec.add_dependency 'hpricot', '~>0.8.6'
+  spec.add_dependency 'erubis', '~>2.7.0'
+  spec.add_dependency 'haml2slim', '~>0.4.7'
 end

--- a/erb2slim.gemspec
+++ b/erb2slim.gemspec
@@ -7,10 +7,13 @@ Gem::Specification.new do |spec|
   spec.email        = 'c0untd0wn@wafflestudio.com'
   spec.homepage     = 'https://github.com/c0untd0wn/erb2slim'
   spec.files        = `git ls-files --  lib/* bin/* README.md`.split("\n")
+  spec.executables << 'erb2slim'
 
   spec.add_dependency 'haml', '~>5.1.2'
   spec.add_dependency 'html2haml', '~>2.2.0'
   spec.add_dependency 'hpricot', '~>0.8.6'
   spec.add_dependency 'erubis', '~>2.7.0'
   spec.add_dependency 'haml2slim', '~>0.4.7'
+
+  spec.add_development_dependency 'minitest', '~>5.11.3'
 end

--- a/lib/erb2slim.rb
+++ b/lib/erb2slim.rb
@@ -1,10 +1,10 @@
 require 'haml'
-require 'haml/html'
+require 'html2haml/html'
 require 'haml2slim'
 
 module Erb2Slim
   def self.convert(input)
-    haml = Haml::HTML.new(input, :erb => true, :xhtml => false).render
+    haml = Html2haml::HTML.new(input, :erb => true, :xhtml => false).render
     slim = Haml2Slim.convert!(haml).to_s
     slim
   end

--- a/tests/data/basic_template.erb
+++ b/tests/data/basic_template.erb
@@ -1,0 +1,2 @@
+Hello, <%= @name %>.
+Today is <%= Time.now.strftime('%A') %>.

--- a/tests/data/basic_template.slim
+++ b/tests/data/basic_template.slim
@@ -1,0 +1,2 @@
+| Hello, #{@name}.
+| Today is #{Time.now.strftime('%A')}.

--- a/tests/test_simple.rb
+++ b/tests/test_simple.rb
@@ -1,0 +1,16 @@
+require 'minitest/autorun'
+
+require 'erb2slim'
+
+class TestSimple < Minitest::Test
+  def setup
+    @sut = Erb2Slim
+  end
+
+  def test_convert_basic
+    origin_erb  = File.read(File.join(File.dirname(__FILE__), 'data', 'basic_template.erb'))
+    target_slim = File.read(File.join(File.dirname(__FILE__), 'data', 'basic_template.slim'))
+    assert_equal target_slim, @sut.convert(origin_erb)
+  end
+end
+


### PR DESCRIPTION
The gem does not work anymore, as HAML has evolved since the last changes. This change set fixes that, and includes a few extras for the future:

* Bundler-based dependency management.
* The gem installs an `erb2slim` basic executable.
* Tiny test for sanity.
* CI integration into GitHub Actions.